### PR TITLE
Add alias name as an allowed Name.use value

### DIFF
--- a/schema/ukrdc/Types/Name.xsd
+++ b/schema/ukrdc/Types/Name.xsd
@@ -60,6 +60,11 @@
             </xs:annotation>
             <xs:simpleType>
                 <xs:restriction base="xs:string">
+                    <xs:enumeration value="A">
+                        <xs:annotation>
+                            <xs:documentation>Alias Name</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
                     <xs:enumeration value="B">
                         <xs:annotation>
                             <xs:documentation>Birth Name</xs:documentation>


### PR DESCRIPTION
This should resolve RADAR to RDA failing with `pyxb.exceptions_.SimpleFacetValueError: Type <class 'ukrdc_schema.ukrdc_schema.STD_ANON_109'> enumeration constraint violated by value A`

E.g. https://github.com/renalreg/services/runs/4549380364?check_suite_focus=true#step:6:200