### PR TITLE
Add automatic version setter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [scripts/README.md](./scripts/README.md) for details.
 
 ## Developer Notes
 
-### Setting library versions
+### Setting versions
 
 To set the XSD schema version *and* both library versions (PyXB and XSData), run:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See [scripts/README.md](./scripts/README.md) for details.
 
 ### Setting library versions
 
-To set both library versions (PyXB and XSData) to the same version, run:
+To set the XSD schema version *and* both library versions (PyXB and XSData), run:
 
 `./setversions.sh ${VERSION_TO_SET}`
 

--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ This contains a script to produce an Excel document which compares the UKRDC XML
 It is not currently used.
 
 See [scripts/README.md](./scripts/README.md) for details.
+
+## Developer Notes
+
+### Setting library versions
+
+To set both library versions (PyXB and XSData) to the same version, run:
+
+`./setversions.sh ${VERSION_TO_SET}`
+
+replacing `${VERSION_TO_SET}` with the version you want to set.
+
+Alternatively, you can omit the version number and the script will set the version to the latest git tag, if it is a valid semantic version number.

--- a/schema/ukrdc/UKRDC.xsd
+++ b/schema/ukrdc/UKRDC.xsd
@@ -1,4 +1,4 @@
-<xs:schema xmlns="http://www.rixg.org.uk/" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.rixg.org.uk/" version="3.3.0">
+<xs:schema xmlns="http://www.rixg.org.uk/" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.rixg.org.uk/" version="3.3.0-post1">
 
     <xs:include schemaLocation="Allergies/Allergy.xsd"/>
     <xs:include schemaLocation="ClinicalRelationships/ClinicalRelationship.xsd"/>

--- a/schema/ukrdc/UKRDC.xsd
+++ b/schema/ukrdc/UKRDC.xsd
@@ -1,4 +1,4 @@
-<xs:schema xmlns="http://www.rixg.org.uk/" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.rixg.org.uk/" version="3.3.0-post1">
+<xs:schema xmlns="http://www.rixg.org.uk/" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.rixg.org.uk/" version="3.3.1">
 
     <xs:include schemaLocation="Allergies/Allergy.xsd"/>
     <xs:include schemaLocation="ClinicalRelationships/ClinicalRelationship.xsd"/>

--- a/schema_build/ukrdc_schema/__init__.py
+++ b/schema_build/ukrdc_schema/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "3.3.0-post1"
+__version__ = "3.3.1"

--- a/schema_build/ukrdc_schema/__init__.py
+++ b/schema_build/ukrdc_schema/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '3.3.0.post1'
+__version__ = "3.3.0-post1"

--- a/setversions.sh
+++ b/setversions.sh
@@ -45,9 +45,11 @@ echo "Setting versions to $semver"
 # Set paths to files to be changed
 xsdatapath="xsdata_build/setup.py"
 pyxbpath="schema_build/ukrdc_schema/__init__.py"
+schemapath="schema/ukrdc/UKRDC.xsd"
 
 # Set version in files
 sed -i "s/__version__ = \"[^\"]*\"/__version__ = \"${semver}\"/g" "$pyxbpath"
 sed -i "s/version=\"[^\"]*\"/version=\"${semver}\"/g" "$xsdatapath"
+sed -i "s/version=\"[^\"]*\"/version=\"${semver}\"/g" "$schemapath"
 
 echo "Done"

--- a/setversions.sh
+++ b/setversions.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Matching based on https://gist.github.com/rverst/1f0b97da3cbeb7d93f4986df6e8e5695
+
+# NOTE: This is currently only compatible with standard semantic versions, with pre-release or build metadata separated with a dash (-)
+# E.g. 1.0.0, 1.0.0-alpha.1, 1.0.0-alpha.1+build.1, 1.0.0-post1 etc.
+
+function chsv_check_version() {
+    if [[ $1 =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+        echo "$1"
+    else
+        echo ""
+    fi
+}
+
+function chsv_check_version_ex() {
+    if [[ $1 =~ ^v.+$ ]]; then
+        chsv_check_version "${1:1}"
+    else
+        chsv_check_version "${1}"
+    fi
+}
+
+# Get first argument, if given
+versiontoset=$1
+
+# If not given, find latest git tag
+if [ -z "$versiontoset" ]
+then
+    echo "\$versiontoset is empty. Finding latest git tag"
+    versiontoset=$(git describe --abbrev=0 --tags)
+fi
+
+# Normalize to a semantic version number
+semver=$(chsv_check_version_ex "$versiontoset")
+
+if [ -z "$semver" ]
+then
+    echo "Invalid version code. Exiting"
+    exit 1
+fi
+
+echo "Setting versions to $semver"
+
+# Set paths to files to be changed
+xsdatapath="xsdata_build/setup.py"
+pyxbpath="schema_build/ukrdc_schema/__init__.py"
+
+# Set version in files
+sed -i "s/__version__ = \"[^\"]*\"/__version__ = \"${semver}\"/g" "$pyxbpath"
+sed -i "s/version=\"[^\"]*\"/version=\"${semver}\"/g" "$xsdatapath"
+
+echo "Done"

--- a/xsdata_build/setup.py
+++ b/xsdata_build/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="ukrdc-xsdata",
-    version="3.3.0.post1",
+    version="3.3.0-post1",
     long_description=long_description,
     long_description_content_type='text/markdown',
     author="UK Renal Registry",

--- a/xsdata_build/setup.py
+++ b/xsdata_build/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="ukrdc-xsdata",
-    version="3.3.0-post1",
+    version="3.3.1",
     long_description=long_description,
     long_description_content_type='text/markdown',
     author="UK Renal Registry",


### PR DESCRIPTION
Adds a convenience script to set the XSD schema version and both library versions in one go. A semantic version number can be specified, or omitted and the latest git tag used instead.

## Usage

From the README:

### Setting versions

To set the XSD schema version *and* both library versions (PyXB and XSData), run:

`./setversions.sh ${VERSION_TO_SET}`

replacing `${VERSION_TO_SET}` with the version you want to set.

Alternatively, you can omit the version number and the script will set the version to the latest git tag, if it is a valid semantic version number.

## Files affected

- `xsdata_build/setup.py`
- `schema_build/ukrdc_schema/__init__.py`
- `schema/ukrdc/UKRDC.xsd`
