### PR TITLE
added setup.py to resources repo

### DIFF
--- a/manifest.ini
+++ b/manifest.ini
@@ -1,0 +1,1 @@
+recursive-include schema *.xsd

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+import pkg_resources
+import xml.etree.ElementTree as ET
+
+
+xsd_file_path = pkg_resources.resource_filename('schema.ukrdc', 'UKRDC.xsd')  # File path relative to the repo, like /schema/ukrdc/UKRDC.xsd
+xsd_schema = ET.parse(xsd_file_path)
+root = xsd_schema.getroot()
+version = root.attrib.get('version')  # Get the version attribute from the root element
+
+setup(
+    name='resources',
+    version=version,  # Set the version to correspond with the XSD schema version
+    packages=find_packages(),
+    package_data={'schema.ukrdc': ['*.xsd'], 'schema.pv2': ['*.xsd'], 'schema.rrtf': ['*.xsd']},
+    include_package_data=True
+)


### PR DESCRIPTION
Following on from:
https://renalregistry.atlassian.net/browse/TNG-840

The simplest way by far of making the schemas available for python validation seemed to be to package them up in an installable way. Maybe there are other things in the repo that should be included in the setup.py too? 

I also added a bit of logic to sync the version of the package with the version of the schemas (which still seems set to version 4 on the master branch). 